### PR TITLE
Bug-fix PersistenceConstraint + ChemotaxisConstraint

### DIFF
--- a/build/artistoo-cjs.js
+++ b/build/artistoo-cjs.js
@@ -5565,11 +5565,17 @@ class PersistenceConstraint extends SoftConstraint {
 				}
 			}
 		}
+		//For the crossproduct to yield the cosine, the vectors should be normalized.
+		this.normalize(a); 
 		let dp = 0;
 		for( let i = 0 ; i < a.length ; i ++ ){
 			dp += a[i]*b[i];
 		}
-		return - dp
+
+		//get the strength of this constraint
+		let lambdadir = this.conf["LAMBDA_DIR"][this.C.cellKind(src_type)];
+
+		return - dp*lambdadir
 	}
 	
 	/** Normalize a vector a by its length.
@@ -5679,8 +5685,11 @@ class PersistenceConstraint extends SoftConstraint {
 					for( let j = 0 ; j < dx.length ; j ++ ){
 						dx[j] *= ld;
 					}
-					this.celldirections[t] = dx;
 				}
+				// regardless of whether PERSIST is used, 
+				//the dx vector should be normalised and added to cell directions
+				this.normalize(dx);
+				this.celldirections[t] = dx;
 			}
 		}
 	}
@@ -5889,7 +5898,8 @@ class ChemotaxisConstraint extends SoftConstraint {
 	 @return {number} the change in Hamiltonian for this copy attempt and this constraint.*/
 	/* eslint-disable no-unused-vars*/
 	deltaH( sourcei, targeti, src_type, tgt_type  ){
-		let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei );
+		let sp = this.C.grid.i2p( sourcei ), tp = this.C.grid.i2p( targeti );
+		let delta = this.field.pixt( tp ) - this.field.pixt( sp ); //WAS: let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei )
 		let lambdachem = this.conf["LAMBDA_CH"][this.C.cellKind(src_type)];
 		return -delta*lambdachem
 	}

--- a/build/artistoo.js
+++ b/build/artistoo.js
@@ -5771,11 +5771,17 @@ var CPM = (function (exports) {
 					}
 				}
 			}
+			//For the crossproduct to yield the cosine, the vectors should be normalized.
+			this.normalize(a); 
 			let dp = 0;
 			for( let i = 0 ; i < a.length ; i ++ ){
 				dp += a[i]*b[i];
 			}
-			return - dp
+
+			//get the strength of this constraint
+			let lambdadir = this.conf["LAMBDA_DIR"][this.C.cellKind(src_type)];
+
+			return - dp*lambdadir
 		}
 		
 		/** Normalize a vector a by its length.
@@ -5885,8 +5891,11 @@ var CPM = (function (exports) {
 						for( let j = 0 ; j < dx.length ; j ++ ){
 							dx[j] *= ld;
 						}
-						this.celldirections[t] = dx;
 					}
+					// regardless of whether PERSIST is used, 
+					//the dx vector should be normalised and added to cell directions
+					this.normalize(dx);
+					this.celldirections[t] = dx;
 				}
 			}
 		}
@@ -6095,7 +6104,8 @@ var CPM = (function (exports) {
 		 @return {number} the change in Hamiltonian for this copy attempt and this constraint.*/
 		/* eslint-disable no-unused-vars*/
 		deltaH( sourcei, targeti, src_type, tgt_type  ){
-			let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei );
+			let sp = this.C.grid.i2p( sourcei ), tp = this.C.grid.i2p( targeti );
+			let delta = this.field.pixt( tp ) - this.field.pixt( sp ); //WAS: let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei )
 			let lambdachem = this.conf["LAMBDA_CH"][this.C.cellKind(src_type)];
 			return -delta*lambdachem
 		}

--- a/examples/html/ManyCellsPrefDir.html
+++ b/examples/html/ManyCellsPrefDir.html
@@ -106,7 +106,7 @@ let pconstraint = new CPM.PersistenceConstraint(
 	{
 		// PersistenceConstraint parameters
 		LAMBDA_DIR: [0,100,100], 				// PersistenceConstraint importance per ck
-		PERSIST: [0,.7,0.2]						// Weight of the persistent direction in the
+		PERSIST: [0,.7,.2]						// Weight of the persistent direction in the
 		// computation of the new direction per cellkind
 	} 
 )

--- a/examples/html/artistoo.js
+++ b/examples/html/artistoo.js
@@ -5771,11 +5771,17 @@ var CPM = (function (exports) {
 					}
 				}
 			}
+			//For the crossproduct to yield the cosine, the vectors should be normalized.
+			this.normalize(a); 
 			let dp = 0;
 			for( let i = 0 ; i < a.length ; i ++ ){
 				dp += a[i]*b[i];
 			}
-			return - dp
+
+			//get the strength of this constraint
+			let lambdadir = this.conf["LAMBDA_DIR"][this.C.cellKind(src_type)];
+
+			return - dp*lambdadir
 		}
 		
 		/** Normalize a vector a by its length.
@@ -5885,8 +5891,11 @@ var CPM = (function (exports) {
 						for( let j = 0 ; j < dx.length ; j ++ ){
 							dx[j] *= ld;
 						}
-						this.celldirections[t] = dx;
 					}
+					// regardless of whether PERSIST is used, 
+					//the dx vector should be normalised and added to cell directions
+					this.normalize(dx);
+					this.celldirections[t] = dx;
 				}
 			}
 		}
@@ -6095,7 +6104,8 @@ var CPM = (function (exports) {
 		 @return {number} the change in Hamiltonian for this copy attempt and this constraint.*/
 		/* eslint-disable no-unused-vars*/
 		deltaH( sourcei, targeti, src_type, tgt_type  ){
-			let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei );
+			let sp = this.C.grid.i2p( sourcei ), tp = this.C.grid.i2p( targeti );
+			let delta = this.field.pixt( tp ) - this.field.pixt( sp ); //WAS: let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei )
 			let lambdachem = this.conf["LAMBDA_CH"][this.C.cellKind(src_type)];
 			return -delta*lambdachem
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "Artistoo",
-	"version": "0.9.1",
+	"version": "1.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/hamiltonian/ChemotaxisConstraint.js
+++ b/src/hamiltonian/ChemotaxisConstraint.js
@@ -113,7 +113,8 @@ class ChemotaxisConstraint extends SoftConstraint {
 	 @return {number} the change in Hamiltonian for this copy attempt and this constraint.*/
 	/* eslint-disable no-unused-vars*/
 	deltaH( sourcei, targeti, src_type, tgt_type  ){
-		let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei )
+		let sp = this.C.grid.i2p( sourcei ), tp = this.C.grid.i2p( targeti )
+		let delta = this.field.pixt( tp ) - this.field.pixt( sp ) //WAS: let delta = this.field.pixt( targeti ) - this.field.pixt( sourcei )
 		let lambdachem = this.conf["LAMBDA_CH"][this.C.cellKind(src_type)]
 		return -delta*lambdachem
 	}

--- a/src/hamiltonian/PersistenceConstraint.js
+++ b/src/hamiltonian/PersistenceConstraint.js
@@ -85,11 +85,17 @@ class PersistenceConstraint extends SoftConstraint {
 				}
 			}
 		}
+		//For the crossproduct to yield the cosine, the vectors should be normalized.
+		this.normalize(a) 
 		let dp = 0
 		for( let i = 0 ; i < a.length ; i ++ ){
 			dp += a[i]*b[i]
 		}
-		return - dp
+
+		//get the strength of this constraint
+		let lambdadir = this.conf["LAMBDA_DIR"][this.C.cellKind(src_type)]
+
+		return - dp*lambdadir
 	}
 	
 	/** Normalize a vector a by its length.
@@ -199,8 +205,11 @@ class PersistenceConstraint extends SoftConstraint {
 					for( let j = 0 ; j < dx.length ; j ++ ){
 						dx[j] *= ld
 					}
-					this.celldirections[t] = dx
 				}
+				// regardless of whether PERSIST is used, 
+				//the dx vector should be normalised and added to cell directions
+				this.normalize(dx)
+				this.celldirections[t] = dx
 			}
 		}
 	}


### PR DESCRIPTION
Fix bugs in the DeltaH function of PersistenceConstraint:

 - Normalise vector a ( vector from source pixel to target pixel).
   Otherwise the dot product does not yield the cosine.

 - Multiply resulting dp variable by LambdaDir, otherwise the strength
   of the constraint cannot change.

Fix bug in the PostMCSListener function of PersistenceConstraint:

 - Normalise dx outside of the if statement for the PERSIST parameter
   and add to celldirections.
   The if statement for the PERSIST parameter was set up such
   that dx was not added to celldirections array when PERSIST=1,
   leading to endlessly persistent cells.

Fix bug in the DeltaH function of ChemotaxisConstraint:

 - First obtain ArrayCoordinates for source and target pixels
   before requesting chemokine field pixel values with pixt function.
   This was done correctly in the DeltaHCoarse function, but in the
   DeltaH function the IndexCoordinates were directly put into the
   pixt function, leading to NaN values for DeltaH.