### PR TITLE
Bugfix overflow of 2^16 cells is possible

### DIFF
--- a/src/models/CPM.js
+++ b/src/models/CPM.js
@@ -461,7 +461,18 @@ class CPM extends GridBasedModel {
 	   @param {CellKind} kind - cellkind of the cell that has to be made.
 	   @return {CellId} of the new cell.*/
 	makeNewCellID ( kind ){
-		const newid = ++ this.last_cell_id
+		if (this.nr_cells >= 65533){
+			// here you know that there are indices available in the Uint16 range for new cellIds
+			throw("Max amount of living cells exceeded!")
+		}
+		let newid
+		do{
+			newid = ++this.last_cell_id
+			if (newid >= 65534){
+				this.last_cell_id = 1
+				newid = 1
+			}
+		}  while (this.cellvolume.hasOwnProperty(newid))
 		this.cellvolume[newid] = 0
 		this.setCellKind( newid, kind )
 		return newid

--- a/src/models/model-typedefs.js
+++ b/src/models/model-typedefs.js
@@ -1,9 +1,10 @@
 /** 
-A unique identifier number of a cell on the grid. In classic CPM language, this is often
+A semi-unique identifier number of a cell on the grid. In classic CPM language, this is often
 referred to as 'type', but we use cellid to prevent confusion with the biological meaning
 of 'celltype' (which we call {@link CellKind} to prevent confusion).
 
-The cellid must be a positive integer. The number 0 is reserved for the background.
+The cellid must be a positive integer. The number 0 is reserved for the background. 
+The cellid cannot exceed 2^16; once this is reached, a search is done for available (deleted) cellids.
 @typedef {number} CellId
 */
 


### PR DESCRIPTION
Checks whether a new cellid contains a living cell, and only takes it if not; restarts search when close to 2^16. 
This allows it to search for new valid cellids when all ids under 2^16 have been used once.